### PR TITLE
feat(poster2): upgrade gallery pair showcase + relax title char budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,7 @@ Use this short version when in doubt:
 
 ## 12. Current phase state (as of 2026-03-28)
 
-### Phase 2: bottom SOP baseline — ESTABLISHED
+### Phase 2: bottom SOP baseline — ESTABLISHED + gallery pair tuned
 
 The `bottom_region` resolver path is now the SOP baseline for the behavior layer.
 
@@ -259,10 +259,14 @@ What is established:
 - `bottom_mode` / `gallery_mode` / `gallery_count` / title / subtitle controls are always wired in Stage 2, regardless of template eligibility
 - **bottom mode selection bug — FIXED** (`initPoster2BottomContractControls` no longer has an early return for non-eligible templates)
 - Stage 2 page refactored: two-column Resolver Layout; bottom controls in left panel; debug areas (Result Diagnostics, old Layout Preview) removed; Resolver Layout shows all region rows post-generation via `region_render_status`
+- **Bottom contract gallery pair UI upgraded** (`strip_local_visible_only` count=2): `gallery_shell_height` 88→100, `gallery_items_height` 68→80, `item_width` 260→280, `gap` 20→16; pair renders as a proper pair showcase frame, not a compressed residual strip
+- **Title char budget relaxed** for 1-line clamp + light gallery + dense subtitle scenario: `title_char_budget` 22→36; Python-level pre-truncation no longer cuts titles at 22 chars — CSS `line-clamp: 1` + `text-overflow: ellipsis` handles visual overflow cleanly
+- 116 poster2 tests passing
 
 What this proves:
 - bottom behavior can be declared, resolved, and validated end-to-end through the contract → resolver → renderer → evidence path
 - the SOP baseline pattern is repeatable
+- gallery pair sizing is now a declared resolver output, not an implicit strip default
 
 ### Phase 3: replicate to other regions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,14 @@ See `.env.example` for the full variable reference.
 
 ## poster2 phase state (as of 2026-03-28)
 
-### Phase 2: bottom SOP baseline — ESTABLISHED
+### Phase 2: bottom SOP baseline — ESTABLISHED + gallery pair tuned
 
 - `bottom_region` behavior (`bottom_mode`, `gallery_mode`, `gallery_count`, title/subtitle) is the agreed SOP baseline for behavior-layer rollout
 - **bottom mode selection bug — FIXED**: removed early-return eligibility gate from `initPoster2BottomContractControls` in `frontend/app.js`; controls now always wired regardless of `template_id`
 - Stage 2 page refactored to two-column Resolver Layout design: bottom controls in left panel; Result Diagnostics and old CSS layout preview removed; Resolver Layout section shows all region rows post-generation
+- **Bottom contract gallery pair UI upgraded** (`strip_local_visible_only` count=2): `gallery_shell_height` 88→100, `gallery_items_height` 68→80, `item_width` 260→280, `gap` 20→16; pair now shows as a proper showcase, not a compressed strip
+- **Title char budget relaxed** for 1-line clamp + light gallery + dense subtitle: `title_char_budget` 22→36; visual truncation now deferred to CSS `line-clamp` + `text-overflow: ellipsis` instead of early Python cut
+- 116 poster2 tests passing
 
 ### Phase 3: next
 

--- a/app/services/poster2/template_behavior.py
+++ b/app/services/poster2/template_behavior.py
@@ -967,7 +967,7 @@ def _resolve_bottom_layout_policies(
             bottom_text_emphasis_policy = "copy_priority_strong_title"
             title_line_clamp = 1 if subtitle_length > 58 and title_length > 20 else 2
             subtitle_line_clamp = 2
-            title_char_budget = 22 if title_line_clamp == 1 else 42
+            title_char_budget = 36 if title_line_clamp == 1 else 42
             subtitle_char_budget = 48
             title_band_height = 160
             title_content_pad_top = 16
@@ -1225,7 +1225,7 @@ def _resolve_gallery_distribution_layout(
     layout_table: dict[str, dict[int, tuple[str, str, str, int, int]]] = {
         "strip_local_visible_only": {
             1: ("single_center_focus", "single_showcase_frame", "single_gallery_focus_aspect", "centered_single_spacing", 288, 0),
-            2: ("balanced_pair", "pair_showcase_frame", "spacious_pair_aspect", "relaxed_pair_spacing", 260, 20),
+            2: ("balanced_pair", "pair_showcase_frame", "spacious_pair_aspect", "relaxed_pair_spacing", 280, 16),
             3: ("balanced_triplet", "triplet_balanced_frame", "balanced_triplet_aspect", "balanced_triplet_spacing", 220, 12),
             4: ("dense_quad", "quad_strip_frame", "compact_quad_aspect", "compact_quad_spacing", 196, 16),
         },
@@ -1296,7 +1296,7 @@ def _resolve_gallery_strip_vertical_metrics(
     vertical_table: dict[str, dict[int, tuple[str, int, int]]] = {
         "strip_local_visible_only": {
             1: ("single_gallery_centered_shift", 88, 68),
-            2: ("downshift_for_spacious_pair", 88, 68),
+            2: ("downshift_for_spacious_pair", 100, 80),
             3: ("balanced_triplet_shift", 80, 60),
             4: ("tight_quad_shift", 68, 52),
         },

--- a/docs/poster2/README.md
+++ b/docs/poster2/README.md
@@ -138,7 +138,7 @@ If a new document cannot be placed cleanly into one of the groups above, that is
 
 ## Current Engineering Phase (as of 2026-03-28)
 
-### Phase 2: bottom SOP baseline — ESTABLISHED
+### Phase 2: bottom SOP baseline — ESTABLISHED + gallery pair tuned
 
 The `bottom_region` resolver path is the agreed SOP baseline for the behavior layer rollout.
 
@@ -147,10 +147,14 @@ The `bottom_region` resolver path is the agreed SOP baseline for the behavior la
 - These controls are always wired in Stage 2 regardless of template eligibility (bottom mode selection bug fixed)
 - Stage 2 page refactored to Resolver Layout design: two-column layout, left panel holds copy + renderer + bottom controls, right panel shows Poster Preview and Resolver Layout with all region rows
 - `frontend/` and `docs/` are in sync
+- **Gallery pair showcase upgraded** (`strip_local_visible_only` count=2): `gallery_shell_height` 88→100, `gallery_items_height` 68→80, `item_width` 260→280, gap 20→16; the pair now renders as a proper `pair_showcase_frame`, not a compressed residual strip
+- **Title char budget relaxed** for 1-line clamp + light gallery + dense subtitle: budget raised 22→36 so Python-level pre-truncation no longer cuts product titles mid-word; CSS `line-clamp` handles visual overflow
+- 116 poster2 tests passing
 
 **What this proves under the product baseline:**
 - The `Structure → Control → Beautification` governance order holds: bottom structure was proven in Phase 1, bottom control behavior is now the SOP baseline in Phase 2
 - The resolver path is repeatable: declare mode → resolve bounds → renderer consumes → evidence emitted
+- Gallery pair sizing is a declared resolver output driven by the behavior contract, not an implicit strip default
 
 **What is NOT yet done:**
 - Other regions (header, scenario, product, feature) do not yet have full resolver coverage

--- a/tests/poster2/test_pipeline.py
+++ b/tests/poster2/test_pipeline.py
@@ -700,12 +700,12 @@ class TestPosterPipelineRun:
         assert behavior["gallery_strip_shift_policy"] == "downshift_for_spacious_pair"
         assert behavior["gallery_aspect_policy"] == "spacious_pair_aspect"
         assert behavior["bottom_text_emphasis_policy"] == "copy_priority_strong_title"
-        assert metadata["bottom_contract_review"]["gallery_strip_region"]["bounds"] == {"x": 226, "y": 902, "w": 572, "h": 88}
+        assert metadata["bottom_contract_review"]["gallery_strip_region"]["bounds"] == {"x": 208, "y": 902, "w": 608, "h": 100}
         assert metadata["bottom_contract_review"]["gallery_slots"]["gallery_item_slot_1"]["local_bounds"] == {
-            "x": 146,
+            "x": 128,
             "y": 10,
-            "w": 260,
-            "h": 68,
+            "w": 280,
+            "h": 80,
         }
 
     def test_renderer_metadata_exposes_triplet_gallery_balancing_policy(self):

--- a/tests/poster2/test_renderer.py
+++ b/tests/poster2/test_renderer.py
@@ -535,10 +535,10 @@ class TestGalleryPositions:
         assert resolved.bottom_policy.gallery_spacing_policy == "relaxed_pair_spacing"
         assert resolved.bottom_policy.gallery_shell_frame_policy == "pair_showcase_frame"
         assert resolved.bottom_policy.bottom_text_emphasis_policy == "copy_priority_strong_title"
-        assert [item["x"] for item in gallery_layouts] == [242, 522]
-        assert [item["w"] for item in gallery_layouts] == [260, 260]
+        assert [item["x"] for item in gallery_layouts] == [224, 520]
+        assert [item["w"] for item in gallery_layouts] == [280, 280]
         assert [item["y"] for item in gallery_layouts] == [912, 912]
-        assert [item["h"] for item in gallery_layouts] == [68, 68]
+        assert [item["h"] for item in gallery_layouts] == [80, 80]
 
     def test_three_item_distribution_uses_balanced_triplet_layout(self):
         template = _load_real_template()
@@ -589,8 +589,8 @@ class TestGalleryPositions:
         )
 
         assert layer_class == "state-show"
-        assert 'left:146px;top:10px;width:260px;height:68px;' in markup
-        assert 'left:426px;top:10px;width:260px;height:68px;' in markup
+        assert 'left:128px;top:10px;width:280px;height:80px;' in markup
+        assert 'left:424px;top:10px;width:280px;height:80px;' in markup
 
     def test_visible_gallery_item_count_checks_intersection_with_strip_bounds(self):
         slot_spec = {
@@ -1129,11 +1129,11 @@ class TestStructuredScenarioLayer:
         assert resolved.bottom_policy.subtitle_line_clamp == 2
         assert resolved.bottom_policy.layout_metrics["title_band_height"] == 160
         assert resolved.bottom_policy.layout_metrics["gallery_shell_top"] == 902
-        assert resolved.bottom_policy.layout_metrics["gallery_shell_x"] == 226
-        assert resolved.bottom_policy.layout_metrics["gallery_shell_w"] == 572
-        assert resolved.bottom_policy.layout_metrics["gallery_items_height"] == 68
-        assert resolved.css_vars["--gallery-shell-left"] == "226px"
-        assert resolved.css_vars["--gallery-shell-width"] == "572px"
+        assert resolved.bottom_policy.layout_metrics["gallery_shell_x"] == 208
+        assert resolved.bottom_policy.layout_metrics["gallery_shell_w"] == 608
+        assert resolved.bottom_policy.layout_metrics["gallery_items_height"] == 80
+        assert resolved.css_vars["--gallery-shell-left"] == "208px"
+        assert resolved.css_vars["--gallery-shell-width"] == "608px"
         assert resolved.css_vars["--gallery-shell-radius"] == "24px"
         assert resolved.css_vars["--bottom-title-letter-spacing"] == "0.01em"
         assert resolved.css_vars["--title-band-height"] == "160px"
@@ -1725,9 +1725,9 @@ class TestBottomSplitBehavior:
         assert "--title-line-clamp:" in html_payload
         assert "--subtitle-line-clamp: 2" in html_payload
         assert "--title-stack-gap: 6px" in html_payload
-        assert "--gallery-shell-left: 226px" in html_payload
-        assert "--gallery-shell-width: 572px" in html_payload
-        assert "left:146px;top:10px;width:260px;height:68px;" in html_payload
+        assert "--gallery-shell-left: 208px" in html_payload
+        assert "--gallery-shell-width: 608px" in html_payload
+        assert "left:128px;top:10px;width:280px;height:80px;" in html_payload
 
     def test_bottom_split_dense_quad_limits_title_growth_and_keeps_quad_distribution(self):
         html_payload = self._render_html_payload(


### PR DESCRIPTION
## Summary

- **Gallery pair showcase upgraded** (`strip_local_visible_only`, count=2): `gallery_shell_height` 88→100, `gallery_items_height` 68→80, `item_width` 260→280, `gap` 20→16. Shell gives 10px vertical padding around items; frame extends from x=208 to x=816 (608px wide, was 572px). Pair renders as a proper `pair_showcase_frame`, not a compressed residual strip.
- **Title char budget relaxed** for 1-line clamp + light gallery + dense subtitle scenario: `title_char_budget` 22→36. Python-level pre-truncation no longer cuts product titles mid-word — visual overflow deferred to CSS `line-clamp: 1` + `text-overflow: ellipsis`.
- 116 poster2 tests passing. CLAUDE.md, AGENTS.md, and `docs/poster2/README.md` updated to reflect Phase 2 completion state.

## Test plan

- [x] `pytest tests/poster2/test_renderer.py tests/poster2/test_pipeline.py` — 116 passed, 0 failed
- [x] `gallery_shell_x`, `gallery_shell_w`, `gallery_items_height`, CSS var assertions updated to new geometry
- [x] `gallery_strip_region bounds` and `gallery_item_slot_1 local_bounds` in pipeline tests updated
- [x] All pre-existing failures are unrelated (test_poster_services, test_schemas, test_glibatree_openai — infrastructure/env issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)